### PR TITLE
Add resolver test for query expression

### DIFF
--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dynamodb resolvers something 1`] = `
+{
+  "filter": {
+    "expression": "#shift = :shift",
+    "expressionNames": {
+      "#shift": "shift",
+    },
+    "expressionValues": {
+      ":shift": {
+        "N": 10,
+      },
+    },
+  },
+  "index": "nameIndex",
+  "operation": "Query",
+  "query": {
+    "expression": "#name = :name",
+    "expressionNames": {
+      "#name": "name",
+    },
+    "expressionValues": {
+      ":name": {
+        "S": "test",
+      },
+    },
+  },
+  "select": "ALL_ATTRIBUTES",
+}
+`;
+
+exports[`dynamodb resolvers something 2`] = `
+[
+  {
+    "a": 10,
+  },
+]
+`;

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -1,0 +1,61 @@
+/* test full resolver pipelines */
+
+import { checkResolverValid } from "./helpers";
+import { util } from "..";
+
+describe("dynamodb resolvers", () => {
+  test("something", async () => {
+    const code = `
+    export function request(ctx) {
+        return {
+            operation: "Query",
+            index: "nameIndex",
+            select : "ALL_ATTRIBUTES",
+            query: {
+                "expression" : "#name = :name",
+                "expressionNames": {
+                    "#name": "name",
+                },
+                "expressionValues" : {
+                    ":name" : util.dynamodb.toDynamoDB(ctx.arguments.filter.line),
+                }
+            },
+            filter: {
+                "expression" : "#shift = :shift",
+                "expressionNames": {
+                    "#shift": "shift",
+                },
+                "expressionValues" : {
+                    ":shift" : util.dynamodb.toDynamoDB(ctx.arguments.filter.shift),
+                }
+            },
+        };
+    }
+
+    export function response(ctx) {
+        return ctx.result.items;
+    }
+    `;
+
+    const requestContext = {
+      arguments: {
+        filter: {
+          line: "test",
+          shift: 10,
+        },
+      },
+    };
+
+    await checkResolverValid(code, requestContext, "request");
+
+    const responseContext = {
+      result: {
+        items: [
+          { a: 10 },
+        ],
+      },
+    };
+
+    await checkResolverValid(code, responseContext, "response");
+  });
+});


### PR DESCRIPTION
We need the concept of end-to-end tests for resolver functions, rather than just the utilities that this package includes. That way we can easily test full resolver examples outside of LocalStack.

The test added was a query example, including some of the dynamodb helper functions. A user was having an issue with this specific example.
