### PR TITLE
CI: fix failed deployments

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -85,3 +85,7 @@ jobs:
           path: |
             logs.txt.gz
           retention-days: 7
+      - name: Print the LocalStack logs
+        if: success() || failure()
+        run: |
+          gunzip -c logs.txt.gz

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -54,6 +54,7 @@ jobs:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           APPSYNC_JS_LIBS_VERSION: ${{ github.sha }}
           DEBUG: "1"
+          DISABLE_EVENTS: "1"
       - uses: actions/setup-node@v4
       - name: Install cdk project
         working-directory: cdk


### PR DESCRIPTION
Some PRs are having trouble landing. They don't seem flaky since the failures are repeatable, however they are not changing utils code.

E.g.: 
* https://github.com/localstack/appsync-utils/pull/17

This branch will find out why and fix the issue.
