### PR TITLE
Fix: CI: use pro image

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -49,6 +49,7 @@ jobs:
         uses: LocalStack/setup-localstack@v0.1.2
         with:
           image-tag: 'latest'
+          use-pro: 'true'
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           APPSYNC_JS_LIBS_VERSION: ${{ github.sha }}


### PR DESCRIPTION
For some reason the pro image is not being used when executing the tests. This would normally mean that every test fails, surely?
