### PR TITLE
Handle case when sqlStatementResults doesn't have records field

### DIFF
--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -259,6 +259,34 @@ exports[`rds resolvers toJsonObject 1`] = `
 ]
 `;
 
+exports[`rds resolvers toJsonObject insert or update 1`] = `
+[
+  [
+    {},
+  ],
+]
+`;
+
+exports[`rds resolvers toJsonObject update and select 1`] = `
+[
+  [
+    {},
+  ],
+  [
+    {
+      "ISBN-13": "978-1948132817",
+      "author": "Mark Twain",
+      "title": "Adventures of Huckleberry Finn",
+    },
+    {
+      "ISBN-13": "978-1948132275",
+      "author": "Jack London",
+      "title": "The Call of the Wild",
+    },
+  ],
+]
+`;
+
 exports[`rds resolvers typehints TIMESTAMP 1`] = `
 {
   "type": "TIMESTAMP",

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -209,6 +209,126 @@ describe("rds resolvers", () => {
 
     await checkResolverValid(code, responseContext, "response");
   });
+  test("toJsonObject insert or update", async () => {
+    const responseContext = {
+      "result": JSON.stringify({
+        "sqlStatementResults": [{
+          "numberOfRecordsUpdated": 1,
+          "generatedFields": []
+        }]
+      })
+    };
+
+    const code = `
+        export function request(ctx) {}
+
+        export function response(ctx) {
+            return rds.toJsonObject(ctx.result);
+        }
+        `;
+
+    await checkResolverValid(code, responseContext, "response");
+  })
+
+  test("toJsonObject update and select", async () => {
+    const responseContext = {
+      "result": JSON.stringify({
+        "sqlStatementResults": [{
+          "numberOfRecordsUpdated": 1,
+          "generatedFields": []
+        },
+        {
+          "numberOfRecordsUpdated": 0,
+          "records": [
+            [
+              {
+                "stringValue": "Mark Twain"
+              },
+              {
+                "stringValue": "Adventures of Huckleberry Finn"
+              },
+              {
+                "stringValue": "978-1948132817"
+              }
+            ],
+            [
+              {
+                "stringValue": "Jack London"
+              },
+              {
+                "stringValue": "The Call of the Wild"
+              },
+              {
+                "stringValue": "978-1948132275"
+              }
+            ]
+          ],
+          "columnMetadata": [
+            {
+              "isSigned": false,
+              "isCurrency": false,
+              "label": "author",
+              "precision": 200,
+              "typeName": "VARCHAR",
+              "scale": 0,
+              "isAutoIncrement": false,
+              "isCaseSensitive": false,
+              "schemaName": "",
+              "tableName": "Books",
+              "type": 12,
+              "nullable": 0,
+              "arrayBaseColumnType": 0,
+              "name": "author"
+            },
+            {
+              "isSigned": false,
+              "isCurrency": false,
+              "label": "title",
+              "precision": 200,
+              "typeName": "VARCHAR",
+              "scale": 0,
+              "isAutoIncrement": false,
+              "isCaseSensitive": false,
+              "schemaName": "",
+              "tableName": "Books",
+              "type": 12,
+              "nullable": 0,
+              "arrayBaseColumnType": 0,
+              "name": "title"
+            },
+            {
+              "isSigned": false,
+              "isCurrency": false,
+              "label": "ISBN-13",
+              "precision": 15,
+              "typeName": "VARCHAR",
+              "scale": 0,
+              "isAutoIncrement": false,
+              "isCaseSensitive": false,
+              "schemaName": "",
+              "tableName": "Books",
+              "type": 12,
+              "nullable": 0,
+              "arrayBaseColumnType": 0,
+              "name": "ISBN-13"
+            }
+          ]
+        }
+        ]
+      })
+    };
+
+    const code = `
+        export function request(ctx) {}
+
+        export function response(ctx) {
+            return rds.toJsonObject(ctx.result);
+        }
+        `;
+
+    await checkResolverValid(code, responseContext, "response");
+  })
+
 
   describe("mysql", () => {
     test("raw string", async () => {

--- a/rds/index.js
+++ b/rds/index.js
@@ -10,28 +10,27 @@ export function toJsonObject(inputStr) {
   for (const { records, columnMetadata } of input.sqlStatementResults) {
     const statement = [];
     if(typeof records === 'undefined' ){
-      perStatement.push({});
-      continue;
-    }
-    for (const record of records) {
-      const row = {};
-      if (record.length !== columnMetadata.length) {
-        // TODO: what to do here?!
-        throw new Error("TODO");
+      statement.push({});
+    } else {
+      for (const record of records) {
+        const row = {};
+        if (record.length !== columnMetadata.length) {
+          // TODO: what to do here?!
+          throw new Error("TODO");
+        }
+
+        for (const colNo in record) {
+
+          // TODO: what if the column is not a string?
+          const { stringValue } = record[colNo];
+          const { label } = columnMetadata[colNo];
+
+          row[label] = stringValue;
+        }
+
+        statement.push(row);
       }
-
-      for (const colNo in record) {
-
-        // TODO: what if the column is not a string?
-        const { stringValue } = record[colNo];
-        const { label } = columnMetadata[colNo];
-
-        row[label] = stringValue;
-      }
-
-      statement.push(row);
     }
-
     perStatement.push(statement);
   }
   return perStatement;
@@ -314,37 +313,37 @@ export function createMySQLStatement(...statements) {
 
 
 export const typeHint = {
-  DECIMAL: function(value) {
+  DECIMAL: function (value) {
     return {
       type: "DECIMAL",
       value,
     };
   },
-  JSON: function(value) {
+  JSON: function (value) {
     return {
       type: "JSON",
       value,
     };
   },
-  TIME: function(value) {
+  TIME: function (value) {
     return {
       type: "TIME",
       value,
     };
   },
-  DATE: function(value) {
+  DATE: function (value) {
     return {
       type: "DATE",
       value,
     };
   },
-  UUID: function(value) {
+  UUID: function (value) {
     return {
       type: "UUID",
       value,
     };
   },
-  TIMESTAMP: function(value) {
+  TIMESTAMP: function (value) {
     return {
       type: "TIMESTAMP",
       value: value.toISOString(),

--- a/rds/index.js
+++ b/rds/index.js
@@ -9,7 +9,10 @@ export function toJsonObject(inputStr) {
   let perStatement = [];
   for (const { records, columnMetadata } of input.sqlStatementResults) {
     const statement = [];
-
+    if(typeof records === 'undefined' ){
+      perStatement.push({});
+      continue;
+    }
     for (const record of records) {
       const row = {};
       if (record.length !== columnMetadata.length) {


### PR DESCRIPTION
Handle case when sqlStatementResults doesn't have records field, for example, it contains result of update or insert statement. In this case AWS adds empty object to array.
Example of ctx.result field:
` "result": "{\"sqlStatementResults\":[{\"numberOfRecordsUpdated\":1,\"generatedFields\":[]}]}",`