### PR TITLE
fix toJsonObject export

### DIFF
--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -259,6 +259,40 @@ exports[`rds resolvers toJsonObject 1`] = `
 ]
 `;
 
+exports[`rds resolvers toJsonObject import paths default 1`] = `
+[
+  [
+    {
+      "ISBN-13": "978-1948132817",
+      "author": "Mark Twain",
+      "title": "Adventures of Huckleberry Finn",
+    },
+    {
+      "ISBN-13": "978-1948132275",
+      "author": "Jack London",
+      "title": "The Call of the Wild",
+    },
+  ],
+]
+`;
+
+exports[`rds resolvers toJsonObject import paths fully qualified 1`] = `
+[
+  [
+    {
+      "ISBN-13": "978-1948132817",
+      "author": "Mark Twain",
+      "title": "Adventures of Huckleberry Finn",
+    },
+    {
+      "ISBN-13": "978-1948132275",
+      "author": "Jack London",
+      "title": "The Call of the Wild",
+    },
+  ],
+]
+`;
+
 exports[`rds resolvers toJsonObject insert or update 1`] = `
 [
   [

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -73,6 +73,126 @@ describe("dynamodb resolvers", () => {
 });
 
 describe("rds resolvers", () => {
+  describe("toJsonObject import paths", () => {
+    const context = {
+      result: JSON.stringify({
+        sqlStatementResults: [
+          {
+            numberOfRecordsUpdated: 0,
+            records: [
+              [
+                {
+                  stringValue: "Mark Twain",
+                },
+                {
+                  stringValue: "Adventures of Huckleberry Finn",
+                },
+                {
+                  stringValue: "978-1948132817",
+                },
+              ],
+              [
+                {
+                  stringValue: "Jack London",
+                },
+                {
+                  stringValue: "The Call of the Wild",
+                },
+                {
+                  stringValue: "978-1948132275",
+                },
+              ],
+            ],
+            columnMetadata: [
+              {
+                isSigned: false,
+                isCurrency: false,
+                label: "author",
+                precision: 200,
+                typeName: "VARCHAR",
+                scale: 0,
+                isAutoIncrement: false,
+                isCaseSensitive: false,
+                schemaName: "",
+                tableName: "Books",
+                type: 12,
+                nullable: 0,
+                arrayBaseColumnType: 0,
+                name: "author",
+              },
+              {
+                isSigned: false,
+                isCurrency: false,
+                label: "title",
+                precision: 200,
+                typeName: "VARCHAR",
+                scale: 0,
+                isAutoIncrement: false,
+                isCaseSensitive: false,
+                schemaName: "",
+                tableName: "Books",
+                type: 12,
+                nullable: 0,
+                arrayBaseColumnType: 0,
+                name: "title",
+              },
+              {
+                isSigned: false,
+                isCurrency: false,
+                label: "ISBN-13",
+                precision: 15,
+                typeName: "VARCHAR",
+                scale: 0,
+                isAutoIncrement: false,
+                isCaseSensitive: false,
+                schemaName: "",
+                tableName: "Books",
+                type: 12,
+                nullable: 0,
+                arrayBaseColumnType: 0,
+                name: "ISBN-13",
+              },
+            ],
+          },
+        ],
+      }),
+    };
+
+    test("default", async () => {
+      let importStatement;
+      if (process.env.TEST_TARGET === "AWS_CLOUD") {
+        importStatement =
+          "import { toJsonObject } from '@aws-appsync/utils/rds';";
+      } else {
+        importStatement = "import { toJsonObject } from '../rds';";
+      }
+      const code =
+        importStatement +
+        "\n" +
+        `
+      export function request(ctx) {
+          return toJsonObject(ctx.result);
+      }
+
+      export function response(ctx) {
+      }
+    `;
+      await checkResolverValid(code, context, "request");
+    });
+
+    test("fully qualified", async () => {
+      const code = `
+      export function request(ctx) {
+          return util.rds.toJsonObject(ctx.result);
+      }
+
+      export function response(ctx) {
+      }
+    `;
+      await checkResolverValid(code, context, "request");
+    });
+  });
+
   describe("typehints", () => {
     test("UUID", async () => {
       const code = `

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { toJsonObject } from './rds'
 
 export const dynamodbUtils = {
   toDynamoDB: function(value) {
@@ -179,6 +180,7 @@ export const util = {
     },
   },
   dynamodb: dynamodbUtils,
+  rds: { toJsonObject },
 };
 
 // embedded here because imports don't yet work


### PR DESCRIPTION
The original `@aws-appsync/utils` package allows to import `toJsonObject` in two ways:
```ts
import { toJsonObject } from '@aws-appsync/utils/rds';

const result = toJsonObject(ctx.result);
```
```ts
import { util } from '@aws-appsync/utils';

const result = util.rds.toJsonObject(ctx.result);
```
The change allows to import `toJsonObject` in both ways as it does the original package