### PR TITLE
Fix `rds.toJsonObject` method only supporting string values

### DIFF
--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -248,11 +248,13 @@ exports[`rds resolvers toJsonObject 1`] = `
     {
       "ISBN-13": "978-1948132817",
       "author": "Mark Twain",
+      "id": 12345,
       "title": "Adventures of Huckleberry Finn",
     },
     {
       "ISBN-13": "978-1948132275",
       "author": "Jack London",
+      "id": 67890,
       "title": "The Call of the Wild",
     },
   ],

--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -246,15 +246,41 @@ exports[`rds resolvers toJsonObject 1`] = `
 [
   [
     {
+      "IS ACTIVE": true,
       "ISBN-13": "978-1948132817",
       "author": "Mark Twain",
+      "blob_value": "aGVsbG8=",
       "id": 12345,
+      "tags": [
+        "a",
+        "b",
+      ],
       "title": "Adventures of Huckleberry Finn",
     },
     {
+      "IS ACTIVE": false,
       "ISBN-13": "978-1948132275",
       "author": "Jack London",
+      "blob_value": "d29ybGQ=",
       "id": 67890,
+      "optional_double": 12.34,
+      "tags": [
+        [
+          true,
+          false,
+        ],
+        [
+          1.234,
+        ],
+        [
+          1,
+          2,
+        ],
+        [
+          "a",
+          "b",
+        ],
+      ],
       "title": "The Call of the Wild",
     },
   ],

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -253,7 +253,13 @@ describe("rds resolvers", () => {
                 },
                 {
                   "stringValue": "978-1948132817"
-                }
+                },
+                {
+                  "isNull": true
+                },
+                { "arrayValue": { "stringValues": ["a", "b"] } },
+                { "booleanValue": true },
+                { "blobValue": Buffer.from("hello").toString("base64") }
               ],
               [
                 {
@@ -267,7 +273,21 @@ describe("rds resolvers", () => {
                 },
                 {
                   "stringValue": "978-1948132275"
-                }
+                },
+                {
+                  "doubleValue": 12.34,
+                },
+                { "arrayValue": {
+                    "arrayValues": [
+                      { "booleanValues": [true, false] },
+                      { "doubleValues": [1.234] },
+                      { "longValues": [1, 2] },
+                      { "stringValues": ["a", "b"] },
+                    ],
+                  },
+                },
+                { "booleanValue": false },
+                { "blobValue": Buffer.from("world").toString("base64") },
               ]
             ],
             "columnMetadata": [
@@ -333,7 +353,20 @@ describe("rds resolvers", () => {
                 "nullable": 0,
                 "arrayBaseColumnType": 0,
                 "name": "ISBN-13"
-              }
+              },
+              {
+                "name": "optional_double",
+              },
+              {
+                "name": "tags",
+              },
+              {
+                "name": "is_active",
+                "label": "IS ACTIVE",
+              },
+              {
+                "name": "blob_value",
+              },
             ]
           }
         ]

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -243,6 +243,9 @@ describe("rds resolvers", () => {
             "records": [
               [
                 {
+                  "longValue": 12345
+                },
+                {
                   "stringValue": "Mark Twain"
                 },
                 {
@@ -253,6 +256,9 @@ describe("rds resolvers", () => {
                 }
               ],
               [
+                {
+                  "longValue": 67890
+                },
                 {
                   "stringValue": "Jack London"
                 },
@@ -265,6 +271,21 @@ describe("rds resolvers", () => {
               ]
             ],
             "columnMetadata": [
+              {
+                "type": 4,
+                "typeName": "serial",
+                "label": "id",
+                "schemaName": "",
+                "tableName": "Books",
+                "isAutoIncrement": true,
+                "isSigned": true,
+                "isCurrency": false,
+                "isCaseSensitive": false,
+                "nullable": 0,
+                "precision": 10,
+                "scale": 0,
+                "arrayBaseColumnType": 0
+              },
               {
                 "isSigned": false,
                 "isCurrency": false,

--- a/rds/index.js
+++ b/rds/index.js
@@ -20,12 +20,11 @@ export function toJsonObject(inputStr) {
         }
 
         for (const colNo in record) {
-
-          // TODO: what if the column is not a string?
-          const { stringValue } = record[colNo];
           const { label } = columnMetadata[colNo];
 
-          row[label] = stringValue;
+          // We assume that the record is a simple object with a single key-value pair.
+          // For example, `{ longValue: 1 }` or `{ stringValue: "Acme Corp" }`.
+          row[label] = Object.values(record[colNo])[0];
         }
 
         statement.push(row);


### PR DESCRIPTION
Currently, the `toJsonObject` method from `rds` only supports `{ stringValue: string }`, but other value types can appear in payloads, such as `{ longValue: number }`, `{ doubleValue: number }`, etc. See https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_Field.html for more information.

This PR changes `toJsonObject` so it extracts the values properly. It also uses the row label if available, and the row name as a fallback.