### PR TITLE
Support attribute exists

### DIFF
--- a/.github/workflows/test-appsync-utils.yml
+++ b/.github/workflows/test-appsync-utils.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_API_KEY }}
-  TEST_IMAGE_NAME: public.ecr.aws/lambda/nodejs:16
+  TEST_IMAGE_NAME: public.ecr.aws/lambda/nodejs:18
 
 jobs:
   unit-test:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test-appsync-utils.yml
+++ b/.github/workflows/test-appsync-utils.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Pull test docker image
         run: docker pull $TEST_IMAGE_NAME

--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -38,7 +38,7 @@ exports[`dynamodb resolvers something 2`] = `
 ]
 `;
 
-exports[`rds resolvers attributeExists 1`] = `
+exports[`rds resolvers attributeExists nested or 1`] = `
 {
   "statements": [
     "SELECT * FROM "supplier" WHERE "id" = :P0 AND (("deleted" = :P1) OR ("deleted" IS NULL))",
@@ -47,6 +47,16 @@ exports[`rds resolvers attributeExists 1`] = `
     ":P0": "123456",
     ":P1": false,
   },
+  "variableTypeHintMap": {},
+}
+`;
+
+exports[`rds resolvers attributeExists true false 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE "created" IS NOT NULL AND "deleted" IS NULL",
+  ],
+  "variableMap": {},
   "variableTypeHintMap": {},
 }
 `;
@@ -373,5 +383,75 @@ exports[`rds resolvers typehints UUID 1`] = `
 {
   "type": "UUID",
   "value": "abc123",
+}
+`;
+
+exports[`rds resolvers where mixed inline and 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE "count" <= :P0 AND ("id" = :P1) AND "deleted" IS NULL",
+  ],
+  "variableMap": {
+    ":P0": 10,
+    ":P1": 123456,
+  },
+  "variableTypeHintMap": {},
+}
+`;
+
+exports[`rds resolvers where mixed or/and 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE ("id" = :P0) AND ("id" = :P1) AND "id" = :P2",
+  ],
+  "variableMap": {
+    ":P0": "and eq",
+    ":P1": "or eq 2",
+    ":P2": "id eq",
+  },
+  "variableTypeHintMap": {},
+}
+`;
+
+exports[`rds resolvers where mixed or/and multiple or 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE ("id" = :P0) AND ("id" = :P1) OR ("id" = :P2) AND "id" = :P3",
+  ],
+  "variableMap": {
+    ":P0": "and eq",
+    ":P1": "or eq 1",
+    ":P2": "or eq 2",
+    ":P3": "id eq",
+  },
+  "variableTypeHintMap": {},
+}
+`;
+
+exports[`rds resolvers where nested ors with ands 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE "id" = :P0 AND ("id" = :P1) OR (("id" = :P2) OR ("id" = :P3)) OR ("id" = :P4)",
+  ],
+  "variableMap": {
+    ":P0": "id eq",
+    ":P1": "or 1",
+    ":P2": "or nested 1",
+    ":P3": "or nested 2",
+    ":P4": "final or",
+  },
+  "variableTypeHintMap": {},
+}
+`;
+
+exports[`rds resolvers where single value in and 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE ("id" = :P0)",
+  ],
+  "variableMap": {
+    ":P0": 123456,
+  },
+  "variableTypeHintMap": {},
 }
 `;

--- a/__tests__/__snapshots__/resolvers.test.js.snap
+++ b/__tests__/__snapshots__/resolvers.test.js.snap
@@ -38,6 +38,19 @@ exports[`dynamodb resolvers something 2`] = `
 ]
 `;
 
+exports[`rds resolvers attributeExists 1`] = `
+{
+  "statements": [
+    "SELECT * FROM "supplier" WHERE "id" = :P0 AND (("deleted" = :P1) OR ("deleted" IS NULL))",
+  ],
+  "variableMap": {
+    ":P0": "123456",
+    ":P1": false,
+  },
+  "variableTypeHintMap": {},
+}
+`;
+
 exports[`rds resolvers mysql insert 1`] = `
 {
   "statements": [

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -503,6 +503,31 @@ describe("rds resolvers", () => {
     await checkResolverValid(code, responseContext, "response");
   })
 
+  test("attributeExists", async () => {
+    const code = `
+      export function request(ctx) {
+          const query = rds.select({
+              table: 'supplier',
+              where: {
+                  id: {
+                      eq: "123456"
+                  },
+                  and: [{
+                      or: [
+                          { deleted: { eq: false } },
+                          { deleted: { attributeExists: false } }
+                      ]
+                  }
+                  ]
+              }
+          });
+          return rds.createPgStatement(query);
+      }
+      export function response(ctx) {}
+  `;
+  await checkResolverValid(code, {}, "request");
+  })
+
 
   describe("mysql", () => {
     test("raw string", async () => {

--- a/__tests__/resolvers.test.js
+++ b/__tests__/resolvers.test.js
@@ -225,7 +225,7 @@ describe("rds resolvers", () => {
 
       const context = {
         arguments: {
-          id: new Date(2023, 1, 1),
+          id: new Date(Date.UTC(2023, 1, 1)),
         },
       };
 
@@ -707,7 +707,7 @@ describe("rds resolvers", () => {
         arguments: {
           id: "1232",
           name: "hello",
-          started: new Date(2022, 2, 2),
+          started: new Date(Date.UTC(2022, 2, 2)),
         }
       };
 
@@ -898,7 +898,7 @@ describe("rds resolvers", () => {
         arguments: {
           id: "1232",
           name: "hello",
-          started: new Date(2022, 2, 2),
+          started: new Date(Date.UTC(2022, 2, 2)),
         }
       };
 

--- a/rds/index.js
+++ b/rds/index.js
@@ -318,6 +318,8 @@ class StatementBuilder {
         return `${startGrouping}${this.quoteChar}${columnName}${this.quoteChar} LIKE ${value}${endGrouping}`;
       case "notContains":
         return `${startGrouping}${this.quoteChar}${columnName}${this.quoteChar} NOT LIKE ${value}${endGrouping}`;
+      case "attributeExists":
+        return `${startGrouping}${this.quoteChar}${columnName}${this.quoteChar} ${value? "IS" : "NOT"} NULL${endGrouping}`;
       default:
         throw new Error(`Unhandled condition type ${conditionType}`);
     }

--- a/rds/index.js
+++ b/rds/index.js
@@ -282,10 +282,9 @@ class StatementBuilder {
           // TODO properly handle errors to return a more useful message
           throw new Error(`'${key}' expects conditions to be an array`);
         }
-        const parts = [];
-        for (const part of where[key]) {
-          parts.push(this.buildWhereClause(part, "(", ")", ops));
-        }
+        const parts = where[key].map(
+          part => this.buildWhereClause(part, "(", ")", ops)
+        );
         blocks.push(`${startGrouping}${parts.join(` ${ops} `)}${endGrouping}`);
       } else {
         // implicit single clause

--- a/test_in_docker.sh
+++ b/test_in_docker.sh
@@ -18,7 +18,7 @@ if [ -z ${TEST_IN_DOCKER_ENTRYPOINT:-} ]; then
         --workdir /test \
         --entrypoint bash \
         -e TEST_IN_DOCKER_ENTRYPOINT=1 \
-        ${TEST_IMAGE_NAME:-public.ecr.aws/lambda/nodejs:16} /test_in_docker.sh
+        ${TEST_IMAGE_NAME:-public.ecr.aws/lambda/nodejs:18} /test_in_docker.sh
 else
     # entrypoint
     echo Entrypoint


### PR DESCRIPTION
## Motivation

This pr implements support for `attributeExists` in rds `where` clause.

The customer sample was also failing as part of the logic in the `where` clause was missing. 

## Changes

- Added support for `attributeExists`
- Allow for multiple blocks on the same level. The previous logic would, in order, either process `or`, process `and` or process a single clause. But only the first of these items would actually make it part of the SQL query.
- allow for nested `and/or` clause. We are calling `buildWhereClause` recursively to correctly build nested `and/or` clauses.
- `buildWhereClause` now correctly returns a string. All usage of  `buildWhereClause` were adding it in a string literal. This would create invalid SQL statement if an array is returned.

Other fixes along the way
- Updated node version to 18 as this is the current version used inside LocalStack
- Fixed `Date` usage in some test, as they would fail in a non UTC environment